### PR TITLE
feat: do not format URLs in code tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
       - '*' # Push events to matching any tag format, i.e. 1.0, 20.15.10
 
 env:
-  PLUGIN_NAME: logseq-plugin-automatic-url-title
+  PLUGIN_NAME: logseq-plugin-automatic-url-title-fork
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 ## Logseq Plugin Automatic URL title
 
-#### :warning: Alert: I won't maintain this repo anymore. I consider it complete because it fulfills the requirements that I need. If you need an additional feature or bug to be fixed please feel free to fork the repo and go crazy with it. Thank you :)
-
 Automatically fetches the title of a website and wraps it into markdown link format. Also, renders the favicon of the url next to it.
 
 ![demo](demo.gif)

--- a/index.ts
+++ b/index.ts
@@ -2,6 +2,7 @@ import '@logseq/libs';
 
 const DEFAULT_REGEX = {
     wrappedInCommand: /(\{\{(video)\s*(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})\s*\}\})/gi,
+    wrappedInCodeTags: /((`|```).*(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,}).*(`|```))/gi,
     htmlTitleTag: /<title(\s[^>]+)*>([^<]*)<\/title>/,
     line: /(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/gi,
     imageExtension: /\.(gif|jpe?g|tiff?|png|webp|bmp|tga|psd|ai)$/i,
@@ -67,6 +68,15 @@ function isAlreadyFormatted(text, url, urlIndex, formatBeginning) {
     return text.slice(urlIndex - 2, urlIndex) === formatBeginning;
 }
 
+function isWrappedInCodeTags(text, url) {
+    const wrappedLinks = text.match(DEFAULT_REGEX.wrappedInCodeTags);
+    if (!wrappedLinks) {
+        return false;
+    }
+
+    return wrappedLinks.some(command => command.includes(url));
+}
+
 function isWrappedInCommand(text, url) {
     const wrappedLinks = text.match(DEFAULT_REGEX.wrappedInCommand);
     if (!wrappedLinks) {
@@ -110,7 +120,7 @@ async function parseBlockForLink(uuid: string) {
     for (const url of urls) {
         const urlIndex = text.indexOf(url, offset);
 
-        if (isAlreadyFormatted(text, url, urlIndex, formatSettings.formatBeginning) || isImage(url) || isWrappedInCommand(text, url)) {
+        if (isAlreadyFormatted(text, url, urlIndex, formatSettings.formatBeginning) || isImage(url) || isWrappedInCommand(text, url) || isWrappedInCodeTags(text, url)) {
             continue;
         }
 


### PR DESCRIPTION
- backport from https://github.com/0x7b1/logseq-plugin-automatic-url-title/pull/16